### PR TITLE
Update in train.py on line 113 & 117

### DIFF
--- a/train.py
+++ b/train.py
@@ -110,11 +110,11 @@ def train(epoch,args):
         inputs, targets = Variable(inputs), Variable(targets)
         outputs = net(inputs)
         loss = criterion(outputs, targets)
-        lossd = loss.data[0]
+        lossd = loss.item()
         loss.backward()
         optimizer.step()
 
-        train_loss += loss.data[0]
+        train_loss += loss.item()
         outputs = outputs[0] # 0=cos_theta 1=phi_theta
         _, predicted = torch.max(outputs.data, 1)
         total += targets.size(0)


### PR DESCRIPTION
invalid index of a 0-dim tensor on line 113 & 117 on loss.data[0]. newer versions of pytorch will fail to execute thus changed to loss.item()  this returns the python number contained in 1 element tensor. For more information: https://github.com/pytorch/pytorch/issues/6061